### PR TITLE
[Fix] Delete endpoint

### DIFF
--- a/src/api/data.js
+++ b/src/api/data.js
@@ -60,6 +60,13 @@ router.delete("/", async (req, res) => {
     const table = req.body.table;
     const data = req.body.data;
 
+    if (!table || !data?.id) {
+        res.status(400).send({
+            message: "Invalid body provided, expected table and data"
+        });
+        return;
+    }
+
     let text = null;
     const values = [data.id];
 
@@ -80,10 +87,6 @@ router.delete("/", async (req, res) => {
     res.status(200).send({
         message: `PUT completed for ${table} ${data.id}`
     })
-
-    res.status(400).send({
-        message: "Invalid body provided, expected table and data"
-    });
 });
 
 const upsert = async (body, res) => {


### PR DESCRIPTION
This fixes an issue where the `delete` endpoint would attempt to respond twice to the same request. The validation is now done before processing the request. An invalid response will now be sent at the correct point of execution.