### PR TITLE
Support batch/transaction uploads

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,7 +1,7 @@
 import 'dotenv/config';
 
 const config = {
-  port: 6000,
+  port: process.env.PORT ? parseInt(process.env.PORT) : 6060,
   database: {
     host: process.env.DATABASE_HOST,
     port: process.env.DATABASE_PORT,


### PR DESCRIPTION
This adds a new API to handle batch uploads in a single transaction, and fixes handling of PATCH.

This also handles arbitrary tables and columns, instead of just the hardcoded todos and lists. This is theoretically bad for security, but makes it easy to change the tables during development.

This also changes the default port to 6060, since 6000 is a "dangerous" port and the web client cannot connect directly to it.