### PR TITLE
Fix number conversion not a function

### DIFF
--- a/src/persistance/mongo/mongo-schema.js
+++ b/src/persistance/mongo/mongo-schema.js
@@ -2,7 +2,7 @@ export const types = {
   date: (v) => new Date(v),
   boolean: (v) => !!v,
   string: (v) => String(v),
-  number: (v) => number(v)
+  number: (v) => Number(v)
 };
 
 export const schema = {


### PR DESCRIPTION
In the mongo persister, the Number type conversion uses a function called `number()` which is not defined. This has been switched out for `Number()` which is [included globally](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/Number)