### PR TITLE
New API Method for Token Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ The endpoints are as follows:
 1. GET `/api/auth/token`
 
    - PowerSync uses this endpoint to retrieve a JWT access token which is used for authentication.
+   - Provide an optional user_id url query parameter to set the subject of the JWT
+
+2. POST `/api/auth/token`
+
+   - PowerSync uses this endpoint to retrieve a JWT access token which is used for authentication.
+   - Provide an optional user_id url query parameter to set the subject of the JWT
+   - Provide a JSON body to the request to set custom claims in the JWT
 
 2. GET `/api/auth/keys`
 

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -51,24 +51,29 @@ async function ensureKeys() {
 
 /**
  * Get the JWT token that PowerSync will use to authenticate the user
+ * Provide an optional user_id in the url params query string to use as the subject of the token
+ * If no id is provided, "UserID" is used as the subject
  */
 router.get('/token', async (req, res) => {
-  await ensureKeys();
-  const powerSyncKey = keys.privateKey;
-
   const { user_id = 'UserID ' } = req.query;
+  
+  const token = await generateToken(user_id, {});
+  res.send({
+    token: token,
+    powersync_url: config.powersync.url
+  });
+});
 
-  const token = await new SignJWT({})
-    .setProtectedHeader({
-      alg: powerSyncKey.alg,
-      kid: powerSyncKey.kid
-    })
-    .setSubject(user_id)
-    .setIssuedAt()
-    .setIssuer(config.powersync.jwtIssuer)
-    .setAudience(config.powersync.url)
-    .setExpirationTime('5m')
-    .sign(powerSyncKey.key);
+/**
+ * Get the JWT token that PowerSync will use to authenticate the user
+ * Provide a payload in the body of the request as a JSON object to set custom claims in the JWT
+ * If no payload is provided, an empty object is used as the claims payload
+ */
+router.post('/token', async (req, res) => {
+  const { user_id = 'UserID ' } = req.query;
+  const payload = req.body || {};
+
+  const token = await generateToken(user_id, payload);
   res.send({
     token: token,
     powersync_url: config.powersync.url
@@ -87,3 +92,27 @@ router.get('/keys', async (req, res) => {
 });
 
 export { router as authRouter };
+
+/**
+ * Generates a JWT token for the given user_id and payload
+ * @param {string} user_id - The subject of the JWT
+ * @param {Object} payload - The payload of the JWT
+ * @returns {Promise<string>} The generated JWT token
+ */
+const generateToken = async (user_id, payload) => {
+  await ensureKeys();
+  const powerSyncKey = keys.privateKey;
+  const token = await new SignJWT(payload)
+    .setProtectedHeader({
+      alg: powerSyncKey.alg,
+      kid: powerSyncKey.kid
+    })
+    .setSubject(user_id)
+    .setIssuedAt()
+    .setIssuer(config.powersync.jwtIssuer)
+    .setAudience(config.powersync.url)
+    .setExpirationTime('5m')
+    .sign(powerSyncKey.key);
+
+  return token;
+};


### PR DESCRIPTION
This PR introduces a new HTTP method to the `/token` endpoint that allows developers to send POST requests with JSON payloads that will be included as custom claims when requesting a new JWT from the API. This makes the token generation portion more flexible allowing developers to test different JWT options for their sync rules.

Testing was conducted to ensure the existing endpoint still functions in addition to the new method:
1. POST with body: 
```
curl -X POST http://localhost:8081/api/auth/token?user_id=1234 \
  -H 'Content-Type: "application/json"' \
  -d '{"store": "store_1}'
```
2. POST without body: 
```
curl -X POST http://localhost:8081/api/auth/token \
  -H 'Content-Type: "application/json"' 
```
 4. GET without user_id, token subject defaults to "User-Id"
```
 curl -X GET http://localhost:8081/api/auth/token 
```
 6. GET with user_id
 ```
 curl -X GET http://localhost:8081/api/auth/token?user_id=1234 
 ```