### PR TITLE
Increased Development JWT Expiration 

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -111,7 +111,10 @@ const generateToken = async (user_id, payload) => {
     .setIssuedAt()
     .setIssuer(config.powersync.jwtIssuer)
     .setAudience(config.powersync.url)
-    .setExpirationTime('5m')
+    // Long-lived tokens should only be used for development purposes. 
+    // Powersync won't authenticate tokens that expire on or after 60 minutes.
+    // See: https://docs.powersync.com/installation/authentication-setup/custom
+    .setExpirationTime('60m')
     .sign(powerSyncKey.key);
 
   return token;


### PR DESCRIPTION
This PR introduces a small change to the expiration time of the development JWTs, increasing it from 5 minutes to 60 minutes.  The comments in the `generateToken` funcion offers guidance for developers on what not to do and why > 60 minute tokes wont work, with a link to the docs. 