### PR TITLE
Add support for attachments using file storage

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -6,3 +6,5 @@ JWT_ISSUER=
 # Either 'mongodb', 'mysql', 'mssql' or 'postgres'. This defaults to Postgres
 DATABASE_TYPE=
 DATABASE_URI=
+# Directory where uploaded attachments are stored. Defaults to ./attachments
+ATTACHMENTS_DIR=

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 error.log
 combined.log
 *.tsbuildinfo
+attachments

--- a/README.md
+++ b/README.md
@@ -17,21 +17,35 @@ The endpoints are as follows:
    - Provide an optional user_id url query parameter to set the subject of the JWT
    - Provide a JSON body to the request to set custom claims in the JWT
 
-2. GET `/api/auth/keys`
+3. GET `/api/auth/keys`
 
    - PowerSync uses this endpoint to validate the JWT returned from the endpoint above.
 
-3. PUT `/api/data`
+4. PUT `/api/data`
 
    - PowerSync uses this endpoint to sync upsert events that occurred on the client application.
 
-4. PATCH `/api/data`
+5. PATCH `/api/data`
 
    - PowerSync uses this endpoint to sync update events that occurred on the client application.
 
-5. DELETE `/api/data`
+6. DELETE `/api/data`
 
    - PowerSync uses this endpoint to sync delete events that occurred on the client application.
+
+7. PUT `/api/attachments/:id`
+
+   - PowerSync uses this endpoint to upload a file for use with the [attachments](https://docs.powersync.com/usage/use-case-examples/attachments-files) API.
+
+8. GET `/api/attachments/:id`
+
+   - PowerSync uses this endpoint to download a previously uploaded attachment.
+
+9. DELETE `/api/attachments/:id`
+
+   - PowerSync uses this endpoint to delete a previously uploaded attachment.
+
+> Attachments are stored on the local filesystem under `attachments/` for demo purposes only — there is no auth on these endpoints and the directory is ephemeral under Docker. For production, back the client's storage adapter with an object store (S3, Cloudflare R2, Supabase Storage, etc.).
 
 ## Packages
 
@@ -49,6 +63,7 @@ The endpoints are as follows:
 
 Based on configuration, this app needs a Postgres, Mongo, MSSQL or MySQL instance. Easiest is probably to use docker containers for these databases.
 Hosted free versions that can also be used:
+
 1. Postgres: For a free version for testing/demo purposes, visit [Supabase](https://supabase.com/).
 2. MSSQL: For a free version of Azure SQL for testing/demo purposes, visit [Azure SQL](https://learn.microsoft.com/en-us/azure/azure-sql/database/free-offer?view=azuresql).
 
@@ -115,7 +130,7 @@ Connections                   ttl     opn     rt1     rt5     p50     p90
                               1957    0       0.04    0.03    0.01    89.93
 ```
 
-3. Open the [PowerSync Dashboard](https://powersync.journeyapps.com/) and paste the `Forwarding` URL starting with HTTPS into the Credentials tab of your PowerSync instance e.g.
+3. Open the [PowerSync Dashboard](https://dashboard.powersync.com/) and paste the `Forwarding` URL starting with HTTPS into the Credentials tab of your PowerSync instance e.g.
 
 ```
 JWKS URI

--- a/app.js
+++ b/app.js
@@ -1,12 +1,10 @@
 import express from 'express';
-import bodyParser from 'body-parser';
 import { apiRouter } from './src/api/index.js';
 import logRequest from './src/middleware/logger.js';
 import config from './config.js';
 
 const app = express();
 
-app.use(bodyParser.json());
 app.use(logRequest);
 
 app.use((req, res, next) => {

--- a/config.js
+++ b/config.js
@@ -11,6 +11,9 @@ const config = {
     publicKey: process.env.POWERSYNC_PUBLIC_KEY,
     privateKey: process.env.POWERSYNC_PRIVATE_KEY,
     jwtIssuer: process.env.JWT_ISSUER
+  },
+  attachments: {
+    dir: process.env.ATTACHMENTS_DIR || './attachments'
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,10 @@
 import app from './app.js';
 import config from './config.js';
+import { ensureAttachmentsDir } from './src/api/attachments.js';
 
 const PORT = process.env.PORT || config.port;
+
+ensureAttachmentsDir();
 
 app.listen(PORT, () => {
   console.log(`Server is running @ http://127.0.0.1:${PORT}`);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "check": "tsc -b"
   },
   "dependencies": {
-    "body-parser": "^1.20.2",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "jose": "^5.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      body-parser:
-        specifier: ^1.20.2
-        version: 1.20.3
       dotenv:
         specifier: ^16.3.1
         version: 16.4.5

--- a/src/api/attachments.js
+++ b/src/api/attachments.js
@@ -1,0 +1,102 @@
+import express from 'express';
+import { mkdirSync, createReadStream } from 'node:fs';
+import { writeFile, unlink } from 'node:fs/promises';
+import path from 'node:path';
+import config from '../../config.js';
+
+const router = express.Router();
+
+/**
+ * Directory where uploaded attachments are stored, from config.attachments.dir
+ * (ATTACHMENTS_DIR env var, defaulting to ./attachments).
+ */
+const ATTACHMENTS_DIR = path.resolve(config.attachments.dir);
+
+/**
+ * Create the attachments directory if it doesn't exist. Call this from
+ * application startup; throws (failing startup) if the directory can't be created.
+ */
+export function ensureAttachmentsDir() {
+  mkdirSync(ATTACHMENTS_DIR, { recursive: true });
+}
+
+/**
+ * Resolve the on-disk path for an attachment id.
+ * path.basename strips any directory components ("../", leading slashes), so a
+ * fixed directory + basename keeps every read/write contained to ATTACHMENTS_DIR.
+ */
+const filePathFor = (id) => path.join(ATTACHMENTS_DIR, path.basename(id));
+
+/**
+ * Upload an attachment. The raw request body is written to disk as-is.
+ * The client's remoteStorage adapter sends the file bytes in the body.
+ */
+router.put('/:id', express.raw({ type: '*/*', limit: '50mb' }), async (req, res) => {
+  if (!req.body || req.body.length === 0) {
+    res.status(400).send({
+      message: 'Invalid body provided, expected file contents'
+    });
+    return;
+  }
+
+  try {
+    await writeFile(filePathFor(req.params.id), req.body);
+
+    res.status(201).send({
+      message: `Upload completed for ${req.params.id}`
+    });
+  } catch (e) {
+    console.error(e.stack ?? e.message);
+    res.status(400).send({
+      message: `Request failed: ${e.message}`
+    });
+  }
+});
+
+/**
+ * Download an attachment.
+ */
+router.get('/:id', (req, res) => {
+  const stream = createReadStream(filePathFor(req.params.id));
+
+  stream.on('open', () => {
+    res.setHeader('Content-Type', 'application/octet-stream');
+    stream.pipe(res);
+  });
+
+  stream.on('error', (e) => {
+    if (e.code === 'ENOENT') {
+      res.status(404).send({
+        message: `Attachment not found: ${req.params.id}`
+      });
+      return;
+    }
+    console.error(e.stack ?? e.message);
+    res.status(400).send({
+      message: `Request failed: ${e.message}`
+    });
+  });
+});
+
+/**
+ * Delete an attachment. Deleting a nonexistant file is treated as success.
+ */
+router.delete('/:id', async (req, res) => {
+  try {
+    await unlink(filePathFor(req.params.id));
+  } catch (e) {
+    if (e.code !== 'ENOENT') {
+      console.error(e.stack ?? e.message);
+      res.status(400).send({
+        message: `Request failed: ${e.message}`
+      });
+      return;
+    }
+  }
+
+  res.status(200).send({
+    message: `Delete completed for ${req.params.id}`
+  });
+});
+
+export { router as attachmentsRouter };

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,10 +1,12 @@
 import express from 'express';
 import { authRouter } from './auth.js';
 import { dataRouter } from './data.js';
+import { attachmentsRouter } from './attachments.js';
 
 const router = express.Router();
 
 router.use('/auth', authRouter);
 router.use('/data', dataRouter);
+router.use('/attachments', attachmentsRouter);
 
 export { router as apiRouter };

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -5,8 +5,8 @@ import { attachmentsRouter } from './attachments.js';
 
 const router = express.Router();
 
-router.use('/auth', authRouter);
-router.use('/data', dataRouter);
+router.use('/auth', express.json(), authRouter);
+router.use('/data', express.json(), dataRouter);
 router.use('/attachments', attachmentsRouter);
 
 export { router as apiRouter };


### PR DESCRIPTION
Adds basic file storage to the demo for use with the attachments API. Files are stored as `<ATTACHMENTS_DIR>/<filename>.<ext>`, where ATTACHMENTS_DIR is a new env var the user can configure.

This PR also removes the `body-parser` dependency. Previously we would pre-parse all `application/json` requests into objects, but since this is not what we want for the attachments route, I replaced the global `body-parser` call with route-specific `express.json()` calls (`express.json()` is a wrapper for `body-parser` and is available since Express 4.16).

### AI Usage

Opus 4.8 generated the initial code for this PR, which I reviewed, tested, and modified manually (mostly error handling, control flow cleanup, and special cases).